### PR TITLE
Reorder queue items

### DIFF
--- a/app/controllers/queue_items_controller.rb
+++ b/app/controllers/queue_items_controller.rb
@@ -15,6 +15,7 @@ class QueueItemsController < ApplicationController
   def destroy
     queue_item = QueueItem.find(params[:id])
     queue_item.destroy if queue_item.user == current_user
+    normalize_queue_item_positions
 
     redirect_to my_queue_path
   end

--- a/app/controllers/queue_items_controller.rb
+++ b/app/controllers/queue_items_controller.rb
@@ -19,6 +19,17 @@ class QueueItemsController < ApplicationController
     redirect_to my_queue_path
   end
   
+  def update_queue
+    begin
+      update_queue_items
+      normalize_queue_item_positions
+    rescue ActiveRecord::RecordInvalid
+      flash[:danger] = 'Position numbers must be integers'
+    end
+
+    redirect_to my_queue_path
+  end
+  
   private
 
   def queue_video(video)
@@ -31,5 +42,20 @@ class QueueItemsController < ApplicationController
 
   def current_user_queued_video?(video)
     QueueItem.find_by(user: current_user, video: video)
+  end
+
+  def update_queue_items
+    QueueItem.transaction do
+      params[:queue_items].each do |queue_item_data|
+        queue_item = QueueItem.find(queue_item_data[:id])
+        queue_item.update!(position: queue_item_data[:position]) if queue_item.user == current_user
+      end
+    end
+  end
+
+  def normalize_queue_item_positions
+    current_user.queue_items.each_with_index do |queue_item, index|
+      queue_item.update(position: index + 1)
+    end
   end
 end

--- a/app/models/queue_item.rb
+++ b/app/models/queue_item.rb
@@ -2,6 +2,8 @@ class QueueItem < ActiveRecord::Base
   belongs_to :user
   belongs_to :video
 
+  validates_numericality_of :position, only_integer: true 
+
   delegate :title, to: :video, prefix: :video
   delegate :category, to: :video
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,5 +2,7 @@ class User < ActiveRecord::Base
   validates_presence_of :email, :password, :full_name
   validates_uniqueness_of :email
 
+  has_many :queue_items
+
   has_secure_password validations: false
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ActiveRecord::Base
   validates_presence_of :email, :password, :full_name
   validates_uniqueness_of :email
 
-  has_many :queue_items
+  has_many :queue_items, ->{ order(:position) }
 
   has_secure_password validations: false
 end

--- a/app/views/queue_items/index.html.haml
+++ b/app/views/queue_items/index.html.haml
@@ -4,7 +4,7 @@
       %article
         %header
           %h2 My Queue
-        = form_tag update_queue_items_path do
+        = form_tag update_queue_path do
           %table.table
             %thead
               %tr

--- a/app/views/queue_items/index.html.haml
+++ b/app/views/queue_items/index.html.haml
@@ -4,29 +4,30 @@
       %article
         %header
           %h2 My Queue
-        %table.table
-          %thead
-            %tr
-              %th(width="10%") List Order
-              %th(width="30%") Video Title
-              %th(width="10%") Play
-              %th(width="20%") Rating
-              %th(width="15%") Genre
-              %th(width="15%") Remove
-          %tbody
-            - @queue_items.each do |queue_item|
+        = form_tag update_queue_items_path do
+          %table.table
+            %thead
               %tr
-                %td
-                  #{queue_item.position}
-                %td
-                  = link_to queue_item.video_title, queue_item.video
-                %td
-                  = button_to "Play", nil, class: "btn btn-default"
-                %td
-                  #{queue_item.rating}
-                %td
-                  = link_to queue_item.category_name, queue_item.category
-                %td
-                  = link_to queue_item_path(queue_item), method: :delete do
-                    %i.glyphicon.glyphicon-remove
-        = button_to "Update Instant Queue", nil, class: "btn btn-default"
+                %th(width="10%") List Order
+                %th(width="30%") Video Title
+                %th(width="10%") Play
+                %th(width="20%") Rating
+                %th(width="15%") Genre
+                %th(width="15%") Remove
+            %tbody
+              - @queue_items.each do |queue_item|
+                %tr
+                  = hidden_field_tag 'queue_items[][id]', queue_item.id
+                  %td= text_field_tag 'queue_items[][position]', queue_item.position, class: 'form-control'
+                  %td
+                    = link_to queue_item.video_title, queue_item.video
+                  %td
+                    = button_to "Play", nil, class: "btn btn-default"
+                  %td
+                    #{queue_item.rating}
+                  %td
+                    = link_to queue_item.category_name, queue_item.category
+                  %td
+                    = link_to queue_item_path(queue_item), method: :delete do
+                      %i.glyphicon.glyphicon-remove
+          = submit_tag 'Update Instant Queue', class: 'btn btn-default'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Myflix::Application.routes.draw do
     resources :reviews, only: [:create]
   end
   resources :queue_items, only: [:create, :destroy]
+  post '/update_queue', to: 'queue_items#update_queue'
   resources :categories, only: [:show]
   resources :users, only: [:create]
   resources :sessions, only: [:create]

--- a/spec/controllers/queue_items_controller_spec.rb
+++ b/spec/controllers/queue_items_controller_spec.rb
@@ -119,4 +119,107 @@ describe QueueItemsController do
       end
     end
   end
+
+  describe 'POST update_queue' do
+    context 'with valid input' do
+      it 'redirects to the my queue page' do
+        alice = Fabricate(:user)
+        session[:user_id] = alice.id
+        queue_item_one = Fabricate(:queue_item, user: alice, position: 1)
+        queue_item_two = Fabricate(:queue_item, user: alice, position: 2)
+
+        post :update_queue, queue_items: [{ id: queue_item_one.id, position: 2}, { id: queue_item_two.id, position: 1}]
+
+        expect(response).to redirect_to my_queue_path
+      end
+
+      it 'reorders the queue items' do
+        alice = Fabricate(:user)
+        session[:user_id] = alice.id
+        queue_item_one = Fabricate(:queue_item, user: alice, position: 1)
+        queue_item_two = Fabricate(:queue_item, user: alice, position: 2)
+
+        post :update_queue, queue_items: [{ id: queue_item_one.id, position: 2 }, { id: queue_item_two.id, position: 1 }]
+
+        expect(alice.queue_items).to eq([queue_item_two, queue_item_one])
+      end
+      it 'normalizes the position numbers' do
+        alice = Fabricate(:user)
+        session[:user_id] = alice.id
+        queue_item_one = Fabricate(:queue_item, user: alice, position: 1)
+        queue_item_two = Fabricate(:queue_item, user: alice, position: 2)
+
+        post :update_queue, queue_items: [{ id: queue_item_one.id, position: 3 }, { id: queue_item_two.id, position: 2 }]
+
+        expect(alice.queue_items.map(&:position)).to eq([1, 2])
+      end
+    end
+    context 'with invalid input' do
+      it 'redirects to my queue page' do
+        alice = Fabricate(:user)
+        session[:user_id] = alice.id
+        queue_item_one = Fabricate(:queue_item, user: alice, position: 1)
+        queue_item_two = Fabricate(:queue_item, user: alice, position: 2)
+
+        post :update_queue, queue_items: [{ id: queue_item_one.id, position: 3 }, { id: queue_item_two.id, position: 2.35 }]
+
+        expect(response).to redirect_to my_queue_path
+      end
+
+      it 'sets the flash danger message' do
+        alice = Fabricate(:user)
+        session[:user_id] = alice.id
+        queue_item_one = Fabricate(:queue_item, user: alice, position: 1)
+        queue_item_two = Fabricate(:queue_item, user: alice, position: 2)
+
+        post :update_queue, queue_items: [{ id: queue_item_one.id, position: 3 }, { id: queue_item_two.id, position: 2.35 }]
+
+        expect(flash[:danger]).to be_present
+      end
+
+      it 'does not reorder the queue items' do
+        alice = Fabricate(:user)
+        session[:user_id] = alice.id
+        queue_item_one = Fabricate(:queue_item, user: alice, position: 1)
+        queue_item_two = Fabricate(:queue_item, user: alice, position: 2)
+
+        post :update_queue, queue_items: [{ id: queue_item_one.id, position: 3 }, { id: queue_item_two.id, position: 2.35 }]
+
+        expect(queue_item_one.reload.position).to eq(1)
+      end
+    end
+
+    context 'for unauthenticated users' do
+      it 'redirects to the sign in page' do
+        post :update_queue, queue_items: [{ id: 1, position: 3 }, { id: 2, position: 2 }]
+
+        expect(response).to redirect_to sign_in_path
+      end
+    end
+
+    context 'with queue items that do not belong to the current user' do
+      it 'redirects to my queue page' do
+        alice = Fabricate(:user)
+        session[:user_id] = alice.id
+        bob = Fabricate(:user)
+        queue_item_one = Fabricate(:queue_item, user: alice, position: 1)
+        queue_item_two = Fabricate(:queue_item, user: bob, position: 2)
+
+        post :update_queue, queue_items: [{ id: queue_item_one.id, position: 2 }, { id: queue_item_two.id, position: 1 }]
+
+        expect(response).to redirect_to my_queue_path
+      end
+      it 'does not reorder queue items that do not belong to the current user' do
+        alice = Fabricate(:user)
+        session[:user_id] = alice.id
+        bob = Fabricate(:user)
+        queue_item_one = Fabricate(:queue_item, user: alice, position: 1)
+        queue_item_two = Fabricate(:queue_item, user: bob, position: 2)
+
+        post :update_queue, queue_items: [{ id: queue_item_one.id, position: 2 }, { id: queue_item_two.id, position: 1 }]
+
+        expect(queue_item_two.reload.position).to eq(2)
+      end
+    end
+  end
 end

--- a/spec/controllers/queue_items_controller_spec.rb
+++ b/spec/controllers/queue_items_controller_spec.rb
@@ -94,6 +94,16 @@ describe QueueItemsController do
         expect(QueueItem.count).to eq(0)
       end
 
+      it 'normalizes the remaining queue items' do
+        queue_item_one = Fabricate(:queue_item, user: alice, position: 1)
+        queue_item_two = Fabricate(:queue_item, user: alice, position: 2)
+        queue_item_three = Fabricate(:queue_item, user: alice, position: 3)
+
+        delete :destroy, id: queue_item_two.id
+
+        expect(alice.queue_items.map(&:position)).to eq([1, 2])
+      end
+
       it 'does not remove the queue item if the current user does not own it' do
         queue_item = Fabricate(:queue_item, user: Fabricate(:user))
         

--- a/spec/fabricators/queue_item_fabricator.rb
+++ b/spec/fabricators/queue_item_fabricator.rb
@@ -1,3 +1,3 @@
 Fabricator(:queue_item) do
-  
+  position { [1, 2, 3].sample }
 end

--- a/spec/models/queue_item_spec.rb
+++ b/spec/models/queue_item_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe QueueItem do
   it { is_expected.to belong_to(:user) }
   it { is_expected.to belong_to(:video) }
+  it { is_expected.to validate_numericality_of(:position).only_integer }
   
   describe '#video_title' do
     it 'returns the title of the associated video' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,5 +5,5 @@ describe User do
   it { is_expected.to validate_presence_of(:password) }
   it { is_expected.to validate_presence_of(:full_name) }
   it { is_expected.to validate_uniqueness_of(:email) }
-  it { is_expected.to have_many(:queue_items) }
+  it { is_expected.to have_many(:queue_items).order(:position) }
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,4 +5,5 @@ describe User do
   it { is_expected.to validate_presence_of(:password) }
   it { is_expected.to validate_presence_of(:full_name) }
   it { is_expected.to validate_uniqueness_of(:email) }
+  it { is_expected.to have_many(:queue_items) }
 end


### PR DESCRIPTION
- Add update_queue route route and queue_items#update_queue action to allow users to batch update queue item positions
- Add specs for reordering queue items
- Add additional spec for DELETE destroy to ensure queue item positions are normalized after deletion
