### PR TITLE
Password reset integration tests

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -14,5 +14,6 @@ Myflix::Application.configure do
   config.action_controller.allow_forgery_protection    = false
 
   config.action_mailer.delivery_method = :test
+  config.action_mailer.default_url_options = { host: 'test.host' } 
   config.active_support.deprecation = :stderr
 end

--- a/spec/features/user_resets_password_spec.rb
+++ b/spec/features/user_resets_password_spec.rb
@@ -1,9 +1,24 @@
 require 'spec_helper'
 
 feature 'User resets password' do
-  scenario 'user resets password and signs in with new password' do
-    visit home_path
-
+  scenario 'user successfully resets the password' do
+    alice = Fabricate(:user, password: 'old_password')
+    visit sign_in_path
     click_link 'Forgot password?'
+
+    fill_in 'Email Address', with: alice.email 
+    click_button 'Send Email'
+    
+    open_email(alice.email)
+    current_email.click_link('Reset my password')
+
+    fill_in 'New Password', with: 'new_password'
+    click_button 'Reset Password'
+
+    fill_in 'Email Address', with: alice.email
+    fill_in 'Password', with: 'new_password'
+    click_button 'Sign in'
+
+    expect(page).to have_content("Welcome, #{alice.full_name}")
   end
 end


### PR DESCRIPTION
Add integration test to ensure that a user can reset their password, then log in to the site with that newly reset password
